### PR TITLE
Failed to create directories due to filesystem latency

### DIFF
--- a/ClassifyCNV.py
+++ b/ClassifyCNV.py
@@ -35,7 +35,7 @@ def make_results_folder():
     # if not, create it before proceeding
     if not os.path.isdir(os.path.join(home_dir, main_results_folder)):
         try:
-            os.mkdir(os.path.join(home_dir, main_results_folder))
+            os.makedirs(os.path.join(home_dir, main_results_folder), exist_ok = True)
         except OSError:
             print('Cannot create main results folder', main_results_folder)
             sys.exit(1)

--- a/ClassifyCNV.py
+++ b/ClassifyCNV.py
@@ -41,13 +41,13 @@ def make_results_folder():
             sys.exit(1)
     # make the results folder for this run
     try:
-        os.mkdir(path_to_results)
+        os.makedirs(path_to_results, exist_ok = True)
     except OSError:
         print('Cannot create results folder', path_to_results)
         sys.exit(1)
     # make the intermediate folder where the technical files will be saved to
     try:
-        os.mkdir(path_to_intermediate)
+        os.makedirs(path_to_intermediate, exist_ok = True)
     except OSError:
         print('Cannot create intermediate results folder', path_to_intermediate)
         sys.exit(1)

--- a/resources.py
+++ b/resources.py
@@ -5,6 +5,7 @@
 This module contains a list of resources used by the pipeline
 """
 
+import tempfile
 import os
 import sys
 from datetime import datetime
@@ -14,7 +15,11 @@ from collections import OrderedDict
 home_dir = os.path.dirname(os.path.realpath(sys.argv[0]))  # directory where the script is actually located
 run_origin_dir = os.path.abspath(os.getcwd())  # directory where the script is run from
 main_results_folder = 'ClassifyCNV_results'
-run_folder_prefix = 'Result_'
+# Parent directory must exist for before creating temp directory
+os.makedirs(os.path.join(home_dir, main_results_folder), exist_ok = True)
+intermediate_tempf_directory = tempfile.mkdtemp(dir = os.path.join(home_dir, main_results_folder))
+tmp_dir_hash =  os.path.basename(intermediate_tempf_directory)
+run_folder_prefix = os.path.join(tmp_dir_hash, 'Result_')
 run_results_folder = run_folder_prefix + datetime.now().strftime("%d-%b-%Y-%H-%M-%S")
 path_to_results = os.path.join(home_dir, main_results_folder, run_results_folder)
 intermediate_folder = 'Intermediate_files'


### PR DESCRIPTION
#### About
Occasionally, multiple competing jobs on a network-attached filesystem will fail due to latency issues. I am providing the `--outdir` arguments so I am not sure why the default directory is being created anyways. Here is some more information about the failing jobs.

```
[Thu Feb 25 00:42:51 2021]
rule classifycnv:
    input: CANVAS/P0007276/CNV.filtered.vcf
    output: CANVAS/P0007276/Scoresheet.txt, CANVAS/P0007276/CNV.filtered.bed
    jobid: 0
    wildcards: newID=P0007276
[-] Unloading python 3.7  ... 
[+] Loading python 3.7  ... 
[-] Unloading bedtools  2.30.0 
[+] Loading bedtools  2.30.0 
CSI_wes_pipeline/scripts/ClassifyCNV/ClassifyCNV.py Version 1.0.1
Cannot create results folder /gpfs/gsfs12/users/GRIS_NCBR/hgsc_processed/csi_wgs_processing/WGS101/CSI_wes_pipeline/scripts/ClassifyCNV/ClassifyCNV_results/Result_25-Feb-2021-00-42-57
[Thu Feb 25 00:42:57 2021]
Error in rule classifycnv:
    jobid: 0
    output: CANVAS/P0007276/Scoresheet.txt, CANVAS/P0007276/CNV.filtered.bed
    shell:
        
           module load python/3.7
           module load bedtools/2.30.0
           perl CSI_wes_pipeline/scripts/make_cnv_bed.pl CANVAS/P0007276/CNV.filtered.vcf CANVAS/P0007276/CNV.filtered.bed
           CSI_wes_pipeline/scripts/ClassifyCNV/ClassifyCNV.py --infile CANVAS/P0007276/CNV.filtered.bed --cores 2 --GenomeBuild hg38 --outdir /gpfs/gsfs12/users/GRIS_NCBR/hgsc_processed/csi_wgs_processing/WGS101/CANVAS/P0007276
           
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)

```

#### Error message
```
Cannot create results folder /gpfs/gsfs12/users/GRIS_NCBR/hgsc_processed/csi_wgs_processing/WGS101/CSI_wes_pipeline/scripts/ClassifyCNV/ClassifyCNV_results/Result_25-Feb-2021-00-42-57
```

#### Fix in PR
Do not error-out if the directory already exists. Better solution, if the user provides `--outdir` and this folder `run_results_folder = run_folder_prefix + datetime.now().strftime("%d-%b-%Y-%H-%M-%S")` is not being used when the user provides something, do not attempt to create the directory.

**Edited on 2/25/2021 at 1:22PM**
Now I am running into a race condition. I took a closer look at what you are doing when a user provides the `--outdir` option. I didn't realize that you were writing temporary files to ClassifyCNV_results/Result_DD-MM-YYYY-HH-MM-SS and then moving those files after. My initial solution to just ignore any warning when creating that directory if it already existing will cause a race condition. As a temp fi x, I am using [tempfile.mkdtemp()](https://docs.python.org/3/library/tempfile.html#tempfile.mkdtemp) to create a tmp directory for a running instance of ClassifyCNV; however, this is not an optimal solution either. 

To really fix this issue, I would recommend refactoring or rethinking how intermediate files are handled and where they are generated. I think if a user provides the `--outdir` all output should be isolated that that directory. It doesn't make sense to me to generate any temp files relative to ClassifyCNV's source. I would highly recommend against that for the following reason. If you generate temp files relative to the src directory, you may run into issues down the road when building a Singularity image as the container's filesystem is read-only.

With that being said, I would probably make the output directory a required argument, build any temporary file in the user-defined `--outdir`. 

Regards,
@skchronicles

